### PR TITLE
Fix storing and loading zero-dimensional arrays.

### DIFF
--- a/src/loading.jl
+++ b/src/loading.jl
@@ -61,7 +61,8 @@ function load_dir(reader::AbstractReader)::ZGroup
                         #shape and chunks have been pre reversed so reverse chunkidx as well.
                         reverse(chunktuple)
                     end
-                    chunkname = arrayname*"/"*join(chunknametuple, metadata.dimension_separator)
+                    # empty chunk has name "0" this is the case for zero dim arrays
+                    chunkname = arrayname*"/"*(isempty(chunknametuple) ? "0" : join(chunknametuple, metadata.dimension_separator))
                     chunknameidx = get(Returns(0), keyname_dict, chunkname)
                     if chunknameidx > 0
                         rawchunkdata = read_key_idx(reader, chunknameidx)
@@ -69,7 +70,8 @@ function load_dir(reader::AbstractReader)::ZGroup
                         chunkstart = chunktuple .* chunks .+ 1
                         chunkstop = min.(chunkstart .+ chunks .- 1, shape)
                         real_chunksize = chunkstop .- chunkstart .+ 1
-                        if zarr_size == 1
+                        if julia_size == 1
+                            @assert zarr_size == 1
                             shaped_chunkdata = reshape(decompressed_chunkdata, chunks...)
                             shaped_array = reinterpret(UInt8, array)
                             array_view = view(shaped_array, (range.(chunkstart, chunkstop))...)

--- a/src/saving.jl
+++ b/src/saving.jl
@@ -86,7 +86,8 @@ function _save_zarray(writer::AbstractWriter, key_prefix::String, z::ZArray)
                 selectdim(chunk_view, 1, zarr_byte) .= selectdim(array_view, 1, julia_byte)
             end
             compressed_chunkdata = compress(norm_compressor, reshape(shaped_chunkdata,:), zarr_size)
-            chunkname = key_prefix*join(chunktuple, '.')
+            # empty chunk has name "0" this is the case for zero dim arrays
+            chunkname = key_prefix*(isempty(chunktuple) ? "0" : join(chunktuple, '.'))
             write_key(writer, chunkname, compressed_chunkdata)
         end
     end

--- a/src/writers.jl
+++ b/src/writers.jl
@@ -27,6 +27,7 @@ end
 Add a key and value to the store.
 """
 function write_key(d::DirectoryWriter, key::AbstractString, data)::Nothing
+    @assert !endswith(key, "/")
     filename = joinpath([d.path; split(key,"/")])
     mkpath(dirname(filename))
     open(filename, "w") do f

--- a/test/test_edge-cases.jl
+++ b/test/test_edge-cases.jl
@@ -40,3 +40,21 @@ end
         ])
     end
 end
+
+
+@testset "saving and loading zero dimensional array" begin
+    g = ZGroup()
+    a::Array{Float64, 0} = fill(3.25)
+    b::Array{Int8, 0} = fill(Int8(2))
+    c::Array{UInt8, 0} = fill(UInt8(0xFF))
+    g["a"] = a
+    g["b"] = b
+    g["c"] = c
+    mktempdir() do path
+        SmallZarrGroups.save_dir(path, g)
+        gload = SmallZarrGroups.load_dir(path)
+        @test gload["a"][] == 3.25
+        @test gload["b"][] == 2
+        @test gload["c"][] == 0xFF
+    end
+end


### PR DESCRIPTION
The chunk name for a zero-dimensional chunk is "0", not the empty string.

Based on https://github.com/JuliaIO/Zarr.jl/pull/117