### PR TITLE
Make it easier to avoid the file system

### DIFF
--- a/src/loading.jl
+++ b/src/loading.jl
@@ -4,7 +4,7 @@ function load_dir(dirpath::AbstractString)::ZGroup
     reader = if isdir(dirpath)
         DirectoryReader(dirpath)
     elseif isfile(dirpath)
-        BufferedZipReader(dirpath)
+        ZarrZipReader(read(dirpath))
     else
         throw(ArgumentError("loading directory $(repr(dirpath)): No such file or directory"))
     end

--- a/src/readers.jl
+++ b/src/readers.jl
@@ -46,18 +46,17 @@ function read_key_idx(d::DirectoryReader, idx::Int)::Vector{UInt8}
 end
 
 
-struct BufferedZipReader <: AbstractReader
+struct ZarrZipReader <: AbstractReader
     zipfile::ZipBufferReader{Vector{UInt8}}
-    function BufferedZipReader(path)
-        @argcheck isfile(path)
-        new(ZipBufferReader(read(path)))
+    function ZarrZipReader(buffer::Vector{UInt8})
+        new(ZipBufferReader(buffer))
     end
 end
 
-function key_names(d::BufferedZipReader)::Vector{String}
+function key_names(d::ZarrZipReader)::Vector{String}
     return zip_names(d.zipfile)
 end
 
-function read_key_idx(d::BufferedZipReader, idx::Int)::Vector{UInt8}
+function read_key_idx(d::ZarrZipReader, idx::Int)::Vector{UInt8}
     zip_readentry(d.zipfile, idx)
 end

--- a/src/writers.jl
+++ b/src/writers.jl
@@ -40,28 +40,19 @@ end
 Write to an in memory zipfile, that gets saved to disk on close.
 This writer will overwrite any existing file at `path`
 """
-struct BufferedZipWriter <: AbstractWriter
-    zipfile::ZipWriter{IOBuffer}
-    path::String
-    iobuffer::IOBuffer
-    function BufferedZipWriter(path)
-        @argcheck !isdir(path)
-        @argcheck !isdirpath(path)
-        mkpath(dirname(path))
-        iobuffer = IOBuffer()
-        zipfile = ZipWriter(iobuffer)
-        new(zipfile, abspath(path), iobuffer)
+struct ZarrZipWriter{IO_TYPE<:IO} <: AbstractWriter
+    zipfile::ZipWriter{IO_TYPE}
+    function ZarrZipWriter(io)
+        new{typeof(io)}(ZipWriter(io))
     end
 end
 
-function write_key(d::BufferedZipWriter, key::AbstractString, data)::Nothing
+function write_key(d::ZarrZipWriter, key::AbstractString, data)::Nothing
     zip_writefile(d.zipfile, key, data)
     nothing
 end
 
-function closewriter(d::BufferedZipWriter)
+function closewriter(d::ZarrZipWriter)
     close(d.zipfile)
-    open(d.path, "w") do f
-        write(f, take!(d.iobuffer))
-    end
+    nothing
 end


### PR DESCRIPTION
The zip archive readers and writers now don't directly use the file system. They were also renamed.