### PR TITLE
Add `save_zip` and `load_zip` functions.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SmallZarrGroups"
 uuid = "d423b6e5-1c84-4ae2-8d2d-b903aee15ac7"
 authors = ["nhz2 <nhz2@cornell.edu>"]
-version = "0.7.0"
+version = "0.7.1"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/loading.jl
+++ b/src/loading.jl
@@ -11,6 +11,22 @@ function load_dir(dirpath::AbstractString)::ZGroup
     load_dir(reader)
 end
 
+"""
+    load_zip(filename::AbstractString)::ZGroup
+    load_zip(data::Vector{UInt8})::ZGroup
+
+
+Load data in a file `filename` or a `data` vector in ZipStore format.
+"""
+function load_zip(filename::AbstractString)::ZGroup
+    reader = ZarrZipReader(read(filename))
+    load_dir(reader)
+end
+function load_zip(data::Vector{UInt8})::ZGroup
+    reader = ZarrZipReader(data)
+    load_dir(reader)
+end
+
 
 function try_add_attrs!(zthing::Union{ZGroup, ZArray}, reader::AbstractReader, keyname_dict,  key_prefix)
     attrsidx = get(Returns(0), keyname_dict, key_prefix*".zattrs")

--- a/src/saving.jl
+++ b/src/saving.jl
@@ -7,6 +7,8 @@ Note this will delete pre existing data at dirpath
 """
 function save_dir(dirpath::AbstractString, z::ZGroup)
     if endswith(dirpath, ".zip")
+        @argcheck !isdir(dirpath)
+        mkpath(dirname(dirpath))
         save_zip(dirpath, z)
     else
         save_dir(DirectoryWriter(dirpath), z)

--- a/src/saving.jl
+++ b/src/saving.jl
@@ -7,28 +7,38 @@ Note this will delete pre existing data at dirpath
 """
 function save_dir(dirpath::AbstractString, z::ZGroup)
     if endswith(dirpath, ".zip")
-        @argcheck !isdir(dirpath)
-        mkpath(dirname(dirpath))
-        open(dirpath; write=true) do io
-            writer = ZarrZipWriter(io)
-            try
-                save_dir(writer, z)
-            finally
-                closewriter(writer)
-            end
-        end
+        save_zip(dirpath, z)
     else
         save_dir(DirectoryWriter(dirpath), z)
     end
     nothing
 end
-
-"""
-Note this will delete pre existing data at dirpath
-"""
 function save_dir(writer::AbstractWriter, z::ZGroup)
     # TODO add something to prevent loops
     _save_zgroup(writer, "", z::ZGroup)
+end
+
+"""
+    save_zip(filename::AbstractString, z::ZGroup)
+    save_zip(io::IO, z::ZGroup)
+
+Save data in a file `filename` or an `io` in ZipStore format.
+Note this will delete pre existing data in `filename`.
+The `io` passed to this function must be empty.
+This function will not close `io`.
+"""
+function save_zip(filename::AbstractString, z::ZGroup)::Nothing
+    open(filename; write=true) do io
+        save_zip(io, z)
+    end
+end
+function save_zip(io::IO, z::ZGroup)::Nothing
+    writer = ZarrZipWriter(io)
+    try
+        save_dir(writer, z)
+    finally
+        closewriter(writer)
+    end
 end
 
 """

--- a/src/writers.jl
+++ b/src/writers.jl
@@ -37,8 +37,9 @@ function write_key(d::DirectoryWriter, key::AbstractString, data)::Nothing
 end
 
 """
-Write to an in memory zipfile, that gets saved to disk on close.
-This writer will overwrite any existing file at `path`
+Write to an `IO` in ZipStore format.
+The wrapped io will be written to, 
+but will not be seeked or read.
 """
 struct ZarrZipWriter{IO_TYPE<:IO} <: AbstractWriter
     zipfile::ZipWriter{IO_TYPE}


### PR DESCRIPTION
Using `save_dir` and `load_dir` for zip files is now deprecated.