### PR TITLE
Change saving order from F to C

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SmallZarrGroups"
 uuid = "d423b6e5-1c84-4ae2-8d2d-b903aee15ac7"
 authors = ["nhz2 <nhz2@cornell.edu>"]
-version = "0.7.1"
+version = "0.8.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
@@ -25,5 +25,5 @@ DataStructures = "0.18"
 JSON3 = "1"
 StructArrays = "0.6"
 TranscodingStreams = "0.9, 0.10"
-ZipArchives = "0.3, 0.4, 0.5, 1"
+ZipArchives = "1"
 julia = "1.8"

--- a/src/loading.jl
+++ b/src/loading.jl
@@ -108,7 +108,7 @@ function load_dir(reader::AbstractReader)::ZGroup
                 end
             end
 
-            zarray = if metadata.is_column_major
+            zarray = if metadata.is_column_major || ndims(array) ≤ 1
                 ZArray(array;
                     chunks = Tuple(chunks),
                     compressor = metadata.compressor,


### PR DESCRIPTION
Zarr v3 defaults to saving data in C order. This PR changes the order in which chucks are compressed from F to C. This is technically not a breaking change, but this change may significantly affect file size.