### PR TITLE
A predicate function can be used to load a specific array or group.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SmallZarrGroups"
 uuid = "d423b6e5-1c84-4ae2-8d2d-b903aee15ac7"
 authors = ["nhz2 <nhz2@cornell.edu>"]
-version = "0.8.2"
+version = "0.8.3"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"


### PR DESCRIPTION
The predicate function filters keys in the underlying store.